### PR TITLE
fix: SKSK-54 카드목록 드래그하다보면 카드인포 안지워지는 이슈

### DIFF
--- a/src/pages/Home/components/PlaceList/index.tsx
+++ b/src/pages/Home/components/PlaceList/index.tsx
@@ -7,6 +7,7 @@ import styles from './index.module.scss';
 import { DragSlider } from 'junyeol-components';
 import { useQueryParamsStore } from '@/pages/Home/hooks/useQueryParamsStore';
 import { useMapStore } from '@/pages/Home/hooks/useMapStore';
+import { flushSync } from 'react-dom';
 
 interface Props {
   places: PlaceType[];
@@ -23,10 +24,13 @@ const PlaceList = ({ places }: Props) => {
   };
 
   const onHoverCard = (title: string) => {
-    const clickedCards = places?.find(place => place.title === title);
+    const hoveredCard = places?.find(place => place.title === title);
 
-    if (clickedCards) {
-      setPrevInfo(showSelectedPlaceInfoOnMap([clickedCards], mapInfo.current));
+    if (hoveredCard) {
+      const matchedInfo = showSelectedPlaceInfoOnMap([hoveredCard], mapInfo.current);
+      flushSync(() => {
+        setPrevInfo(matchedInfo);
+      });
     } else {
       alert('지도에서 찾지 못한 카드입니다. 개발자에게 문의하세요');
     }

--- a/src/utils/handleMapMarkers.ts
+++ b/src/utils/handleMapMarkers.ts
@@ -103,15 +103,6 @@ export const removeInfo = (infowindow: { close: () => void }) => {
   infowindow.close();
 };
 
-// onClick은 쓰이진 않지만 우선 남겨둠
-export const onKakaoMapClick = (map: any, setPickPoint: (position?: PositionType) => void) => {
-  new window.kakao.maps.event.addListener(map, 'click', (e: { latLng: any }) => {
-    const latlng = { lat: e.latLng.Ma, lon: e.latLng.La };
-
-    setPickPoint(latlng);
-  });
-};
-
 export const onDragMap = (map: any, setPickPoint: (position?: PositionType) => void) => {
   new window.kakao.maps.event.addListener(map, 'dragend', () => {
     const latlng = map.getCenter();


### PR DESCRIPTION
### 원인
- 드래그를 너무 빠르게 할 경우, onHoverCard 이벤트가 종료되고 setPrevInfo가 완료되기 전에 사이드이펙트(카카오맵 관련 동작)이 끼어들면서 setPrevInfo가 완료되지 않음 -> 호버해서 생긴 info가 등록되지 않는다
### 해결
동기화